### PR TITLE
[Fix] Add babel-cli in devDependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,6 +17,7 @@
     "thinkjs": "next"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-preset-think-node": "^1.0.0",
     "node-notifier": "^5.0.2",
     "think-watcher": "^3.0.0",


### PR DESCRIPTION
If global does not exist babel-cli,the NPM Script compile will throw an error.

Checklist
- [x] npm run test passes